### PR TITLE
chore: pin @tootallnate/once to 3.0.1 via yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "resolutions": {
     "cheerio": "1.0.0-rc.12",
     "postcss": "8.5.6",
-    "webpack-dev-server": "5.2.1"
+    "webpack-dev-server": "5.2.1",
+    "@tootallnate/once": "3.0.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Mitigate a Dependabot alert for `@tootallnate/once` (<3.0.1) that is pulled in transitively via `jest-environment-jsdom -> http-proxy-agent` by forcing a patched version.

### Description
- Added a Yarn `resolutions` entry in `package.json` to pin `@tootallnate/once` to `3.0.1` (modified file: `package.json`).

### Testing
- Verified the resolution is present with `node -e "const p=require('./package.json'); console.log(p.resolutions['@tootallnate/once'])"` which printed `3.0.1`, and attempted `yarn install --mode=update-lockfile` to refresh `yarn.lock` but it failed due to an HTTP 403 from the registry so the lockfile was not updated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac807c47108328b89132a4aeb09798)